### PR TITLE
Continue on google failures

### DIFF
--- a/findNfcChipForGoogle.py
+++ b/findNfcChipForGoogle.py
@@ -187,7 +187,7 @@ class FindNfcChipForGoogle:
                         result[2] >= 0.8):  # found the right Number with 80% plausibility
                     number_locations.append(result)
 
-        if number_locations is not None:
+        if number_locations is not None and len(number_locations) > 0:
             sorted(number_locations, key=lambda x: x[2], reverse=True)  # highest plausibility at pos[0]
             x0 = int(number_locations[0][0][0][0] / 4)
             y0 = int(number_locations[0][0][0][1] / 4)

--- a/nfcChipsOutput/nfc_positions.json
+++ b/nfcChipsOutput/nfc_positions.json
@@ -1635,5 +1635,428 @@
                "x1": 0.6,
                "y1": 0.35294117647058826
           }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A23 5G",
+          "modelNames": [
+               "SC-56C",
+               "SCG18",
+               "SM-A233C",
+               "SM-A2360",
+               "SM-A236B",
+               "SM-A236E",
+               "SM-A236M",
+               "SM-A236U",
+               "SM-A236U1",
+               "SM-S236DL",
+               "SM-S237VL"
+          ],
+          "nfcPos": {
+               "x0": 0.08843537414965985,
+               "y0": 0.06129032258064516,
+               "x1": 0.5170068027210885,
+               "y1": 0.2709677419354839
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A15 5G",
+          "modelNames": [
+               "SM-A1560",
+               "SM-A156B",
+               "SM-A156E",
+               "SM-A156M",
+               "SM-A156U",
+               "SM-A156U1",
+               "SM-A156W",
+               "SM-S156V"
+          ],
+          "nfcPos": {
+               "x0": 0.1258278145695364,
+               "y0": 0.07096774193548387,
+               "x1": 0.576158940397351,
+               "y1": 0.2903225806451613
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy S24 Ultra",
+          "modelNames": [
+               "SC-52E",
+               "SCG26",
+               "SM-S9280",
+               "SM-S928B",
+               "SM-S928N",
+               "SM-S928Q",
+               "SM-S928U",
+               "SM-S928U1",
+               "SM-S928W"
+          ],
+          "nfcPos": {
+               "x0": 0.04575163398692805,
+               "y0": 0.010033444816053512,
+               "x1": 0.6862745098039216,
+               "y1": 0.3377926421404682
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A14 5G",
+          "modelNames": [
+               "SM-A146B",
+               "SM-A146M",
+               "SM-A146P",
+               "SM-A146U",
+               "SM-A146U1",
+               "SM-A146W",
+               "SM-S146VL"
+          ],
+          "nfcPos": {
+               "x0": 0.09589041095890416,
+               "y0": 0.07096774193548387,
+               "x1": 0.6095890410958904,
+               "y1": 0.2838709677419355
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy S23",
+          "modelNames": [
+               "SC-51D",
+               "SCG19",
+               "SM-S9110",
+               "SM-S911B",
+               "SM-S911C",
+               "SM-S911N",
+               "SM-S911U",
+               "SM-S911U1",
+               "SM-S911W"
+          ],
+          "nfcPos": {
+               "x0": 0.04054054054054057,
+               "y0": 0.34459459459459457,
+               "x1": 0.9459459459459459,
+               "y1": 0.7533783783783784
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy S24+",
+          "modelNames": [
+               "SM-S9260",
+               "SM-S926U",
+               "SM-S926U1",
+               "SM-S926W",
+               "SM-S926B",
+               "SM-S926N"
+          ],
+          "nfcPos": {
+               "x0": 0.03355704697986572,
+               "y0": 0.02903225806451613,
+               "x1": 0.7248322147651007,
+               "y1": 0.3580645161290323
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A22 5G",
+          "modelNames": [
+               "SC-56B",
+               "SM-A226B",
+               "SM-A226BR"
+          ],
+          "nfcPos": {
+               "x0": 0.14598540145985406,
+               "y0": 0.11290322580645161,
+               "x1": 0.5985401459854014,
+               "y1": 0.3161290322580645
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy S23+",
+          "modelNames": [
+               "SM-S9160",
+               "SM-S916B",
+               "SM-S916N",
+               "SM-S916U",
+               "SM-S916U1",
+               "SM-S916W"
+          ],
+          "nfcPos": {
+               "x0": 0.03355704697986572,
+               "y0": 0.33557046979865773,
+               "x1": 0.9463087248322147,
+               "y1": 0.7550335570469798
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy S23 FE 5G",
+          "modelNames": [],
+          "nfcPos": {
+               "x0": 0.046666666666666634,
+               "y0": 0.3967741935483871,
+               "x1": 0.9333333333333333,
+               "y1": 0.7419354838709677
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy S23 Ultra",
+          "modelNames": [
+               "SC-52D",
+               "SCG20",
+               "SM-S9180",
+               "SM-S918B",
+               "SM-S918N",
+               "SM-S918Q",
+               "SM-S918U",
+               "SM-S918U1",
+               "SM-S918W"
+          ],
+          "nfcPos": {
+               "x0": 0.05405405405405406,
+               "y0": 0.3468013468013468,
+               "x1": 0.9324324324324325,
+               "y1": 0.8316498316498316
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy S24",
+          "modelNames": [
+               "SC-51E",
+               "SCG25",
+               "SM-S9210",
+               "SM-S921Q",
+               "SM-S921U",
+               "SM-S921U1",
+               "SM-S921W",
+               "SM-S921B",
+               "SM-S921N"
+          ],
+          "nfcPos": {
+               "x0": 0.027972027972028024,
+               "y0": 0.06774193548387097,
+               "x1": 0.6993006993006994,
+               "y1": 0.3419354838709677
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy M33 5G",
+          "modelNames": [
+               "SM-M336B",
+               "SM-M336BU"
+          ],
+          "nfcPos": {
+               "x0": 0.07482993197278909,
+               "y0": 0.06129032258064516,
+               "x1": 0.4965986394557823,
+               "y1": 0.23548387096774193
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A53 5G",
+          "modelNames": [
+               "SC-53C",
+               "SCG15",
+               "SM-A5360",
+               "SM-A536B",
+               "SM-A536E",
+               "SM-A536N",
+               "SM-A536U",
+               "SM-A536U1",
+               "SM-A536W",
+               "SM-S536DL"
+          ],
+          "nfcPos": {
+               "x0": 0.014285714285714235,
+               "y0": 0.054838709677419356,
+               "x1": 0.55,
+               "y1": 0.32903225806451614
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A34 5G",
+          "modelNames": [
+               "SM-A3460",
+               "SM-A346B",
+               "SM-A346E",
+               "SM-A346M",
+               "SM-A346N"
+          ],
+          "nfcPos": {
+               "x0": 0.04054054054054057,
+               "y0": 0.016835016835016835,
+               "x1": 0.7297297297297297,
+               "y1": 0.27946127946127947
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A25 5G",
+          "modelNames": [
+               "SM-A2560",
+               "SM-A256B",
+               "SM-A256E",
+               "SM-A256N",
+               "SM-A256U",
+               "SM-A256U1",
+               "SM-S256VL"
+          ],
+          "nfcPos": {
+               "x0": 0.09999999999999998,
+               "y0": 0.06451612903225806,
+               "x1": 0.6,
+               "y1": 0.2967741935483871
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A35 5G",
+          "modelNames": [
+               "SM-A3560",
+               "SM-A356B",
+               "SM-A356E",
+               "SM-A356N",
+               "SM-A356U",
+               "SM-A356U1",
+               "SM-A356W",
+               "SM-S356V"
+          ],
+          "nfcPos": {
+               "x0": 0.09459459459459463,
+               "y0": 0.08387096774193549,
+               "x1": 0.5945945945945945,
+               "y1": 0.3193548387096774
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A13 5G",
+          "modelNames": [
+               "SM-A136B",
+               "SM-A136M",
+               "SM-A136S",
+               "SM-A136U",
+               "SM-A136U1",
+               "SM-A136W",
+               "SM-S136DL"
+          ],
+          "nfcPos": {
+               "x0": 0.07586206896551728,
+               "y0": 0.020134228187919462,
+               "x1": 0.6206896551724138,
+               "y1": 0.24496644295302014
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy M34 5G",
+          "modelNames": [
+               "SM-M346B",
+               "SM-M346B1",
+               "SM-M346B2"
+          ],
+          "nfcPos": {
+               "x0": 0.04166666666666663,
+               "y0": 0.06129032258064516,
+               "x1": 0.6041666666666667,
+               "y1": 0.2838709677419355
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy A55 5G",
+          "modelNames": [
+               "SC-53E",
+               "SCG27",
+               "SM-A5560",
+               "SM-A556B",
+               "SM-A556E"
+          ],
+          "nfcPos": {
+               "x0": 0.11888111888111885,
+               "y0": 0.06451612903225806,
+               "x1": 0.6433566433566433,
+               "y1": 0.3064516129032258
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy Z Fold5 5G",
+          "modelNames": [],
+          "nfcPos": {
+               "x0": 0.0692307692307692,
+               "y0": 0.3967741935483871,
+               "x1": 0.9461538461538461,
+               "y1": 0.7903225806451613
+          }
+     },
+     {
+          "manufacturer": "Samsung",
+          "marketingName": "Samsung Galaxy Z Flip5 5G",
+          "modelNames": [],
+          "nfcPos": {
+               "x0": 0.0948905109489051,
+               "y0": 0.5870967741935483,
+               "x1": 0.8978102189781022,
+               "y1": 0.9354838709677419
+          }
+     },
+     {
+          "manufacturer": "Google",
+          "marketingName": "Pixel 8a",
+          "modelNames": [
+               "Pixel 8a"
+          ],
+          "nfcPos": {
+               "x0": 0.37106918238993714,
+               "y0": 0.0,
+               "x1": 0.9654088050314465,
+               "y1": 0.1411589895988113
+          }
+     },
+     {
+          "manufacturer": "Google",
+          "marketingName": "Pixel 8 ",
+          "modelNames": [],
+          "nfcPos": {
+               "x0": 0.13432835820895528,
+               "y0": 0.13636363636363635,
+               "x1": 0.5970149253731343,
+               "y1": 0.8409090909090909
+          }
+     },
+     {
+          "manufacturer": "Google",
+          "marketingName": "Pixel 8 Pro",
+          "modelNames": [
+               "Pixel 8 Pro"
+          ],
+          "nfcPos": {
+               "x0": 0.24675324675324672,
+               "y0": 1.0,
+               "x1": 0.6623376623376623,
+               "y1": 1.0
+          }
+     },
+     {
+          "manufacturer": "Google",
+          "marketingName": "Pixel 7a",
+          "modelNames": [
+               "Pixel 7a"
+          ],
+          "nfcPos": {
+               "x0": 0.375,
+               "y0": 0.0,
+               "x1": 0.78125,
+               "y1": 0.14402618657937807
+          }
      }
 ]


### PR DESCRIPTION
Instead of cancelling on a find-chip-on-image failure for a google phone, we continue and skip the phone that failed.

Also updated the json data with new data.